### PR TITLE
Add enable/disable unfocused functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Also provide commands for these functions.
 Configuration
 =============
 
-  - `let g:showmarks_auto_toggle = 0`  
+  - `let g:showmarks_auto_toggle = []`  
     Don't open ShowMarks with CursorHold autocommand.
   - `let g:showmarks_no_mappings = 1`  
     Disable default key mappings.

--- a/autoload/showmarks.vim
+++ b/autoload/showmarks.vim
@@ -24,7 +24,14 @@ function! showmarks#ShowMarksToggle()
 	if b:showmarks_shown == 0
 		let g:showmarks_enable = 1
 		call showmarks#ShowMarks()
-		if g:showmarks_auto_toggle
+		if index(g:showmarks_auto_toggle, 'current_buffer') >= 0
+			augroup ShowMarksCurrentBuffer
+				autocmd!
+				autocmd BufEnter * call showmarks#ShowMarks()
+				autocmd BufLeave * call showmarks#ShowMarksHideAll()
+			augroup END
+		endif
+		if index(g:showmarks_auto_toggle, 'cursor_hold') >= 0
 			augroup ShowMarks
 				autocmd!
 				autocmd CursorHold * call showmarks#ShowMarks()
@@ -33,7 +40,13 @@ function! showmarks#ShowMarksToggle()
 	else
 		let g:showmarks_enable = 0
 		call showmarks#ShowMarksHideAll()
-		if g:showmarks_auto_toggle
+		if index(g:showmarks_auto_toggle, 'current_buffer') >= 0
+			" Remove the current buffer autocmd in case the plugin is disabled.
+			augroup ShowMarksCurrentBuffer
+				autocmd!
+			augroup END
+		endif
+		if index(g:showmarks_auto_toggle, 'cursor_hold') >= 0
 			augroup ShowMarks
 				autocmd!
 				autocmd BufEnter * call showmarks#ShowMarksHideAll()

--- a/autoload/showmarks.vim
+++ b/autoload/showmarks.vim
@@ -32,11 +32,11 @@ function! showmarks#ShowMarksToggle()
 		endif
 	else
 		let g:showmarks_enable = 0
-		call s:ShowMarksHideAll()
+		call showmarks#ShowMarksHideAll()
 		if g:showmarks_auto_toggle
 			augroup ShowMarks
 				autocmd!
-				autocmd BufEnter * call s:ShowMarksHideAll()
+				autocmd BufEnter * call showmarks#ShowMarksHideAll()
 			augroup END
 		endif
 	endif
@@ -205,6 +205,16 @@ function! showmarks#ShowMarksHooksMark()
 	call showmarks#ShowMarks()
 endfunction
 
+" Function: ShowMarksHideAll()
+" Description: This function hides all marks in the buffer.
+" It simply removes the signs.
+function! showmarks#ShowMarksHideAll()
+	for placed in s:SignPlacementInfo()
+		execute 'sign unplace ' . placed.id . ' buffer=' . winbufnr(0)
+	endfor
+	let b:showmarks_shown = 0
+endfunction
+
 
 " Function: IncludeMarks()
 " Description: This function returns the list of marks (in priority order) to
@@ -216,7 +226,7 @@ function! s:IncludeMarks()
 	let marks = get(b:, key, get(g:, key, s:all_marks))
 	if get(b:, 'showmarks_previous_include', '') != marks
 		let b:showmarks_previous_include = marks
-		call s:ShowMarksHideAll()
+		call showmarks#ShowMarksHideAll()
 		call showmarks#ShowMarks()
 	endif
 	return marks
@@ -233,16 +243,6 @@ function! s:LineNumberOf(mark)
 	else
 		return pos[1]
 	endif
-endfunction
-
-" Function: ShowMarksHideAll()
-" Description: This function hides all marks in the buffer.
-" It simply removes the signs.
-function! s:ShowMarksHideAll()
-	for placed in s:SignPlacementInfo()
-		execute 'sign unplace ' . placed.id . ' buffer=' . winbufnr(0)
-	endfor
-	let b:showmarks_shown = 0
 endfunction
 
 " Function: DefineSign()

--- a/doc/showmarks.txt
+++ b/doc/showmarks.txt
@@ -54,15 +54,24 @@ behaves:
    ShowMarks can be turned back on using the |ShowMarksToggle| command.
 
                                                       *'showmarks_auto_toggle'*
-'showmarks_auto_toggle'   Number (default: 1)
+'showmarks_auto_toggle'   List (default: ['cursor_hold'])
                           global
-   This option define when the showmarks would be shown and updated.
-    - 0 : activated and updated only by user command.
-    - 1 : activated and updated by |CursorHold| autocommand, and deactivated
-          by |BufEnter| autocommand.
-    - 2 : activated and updated by |CursorHold| autocommand, and deactivated
-          by |BufEnter| autocommand, but work only for the current buffer,
-          not being set on unfocused buffers.
+   This option define if the marks would be shown and updated automatically.
+    - []               : The marks won't be updated or shown automatically
+                         at all.
+    - 'cursor_hold'    : The marks will be shown and updated when the
+                         CursorHold event happens.
+    - 'current_buffer' : The marks would be shown only for the current
+                         buffer.
+
+   Those values can be used together. E.g., setting the value to
+   ['cursor_hold', 'current_buffer'] would mean that the value would be
+   updated automatically, but will be shown only on the current buffer.
+
+   For backward compatibility, this value support also number variables. In
+   case it would be 0 it would turn into [] and in case it would be 1 it
+   would be turned into ['cursor_hold']. However, it is advised to use this
+   variable as a list.
 
                                                       *'showmarks_no_mappings'*
 'showmarks_no_mappings'   boolean (default: 0)

--- a/doc/showmarks.txt
+++ b/doc/showmarks.txt
@@ -167,6 +167,12 @@ behaves:
    This option defines whether the entire line other marks are on will be
    highlighted.
 
+'showmarks_enable_unfocused' boolean (default: 1)        *'showmarks_enable_unfocused'*
+                        global
+   This option defines whether buffers other than the current buffer would
+   have marks on them. By setting this value to 0, only the current focused
+   buffer would show it's marks.
+
 ===============================================================================
 3. Highlighting                                        *showmarks-highlighting*
 

--- a/doc/showmarks.txt
+++ b/doc/showmarks.txt
@@ -54,10 +54,15 @@ behaves:
    ShowMarks can be turned back on using the |ShowMarksToggle| command.
 
                                                       *'showmarks_auto_toggle'*
-'showmarks_auto_toggle'   boolean (default: 1)
+'showmarks_auto_toggle'   Number (default: 1)
                           global
-   This option define whether ShowMarks should be activated by |CursorHold|
-   autocommand, and deactivated by |BufEnter| autocommand.
+   This option define when the showmarks would be shown and updated.
+    - 0 : activated and updated only by user command.
+    - 1 : activated and updated by |CursorHold| autocommand, and deactivated
+          by |BufEnter| autocommand.
+    - 2 : activated and updated by |CursorHold| autocommand, and deactivated
+          by |BufEnter| autocommand, but work only for the current buffer,
+          not being set on unfocused buffers.
 
                                                       *'showmarks_no_mappings'*
 'showmarks_no_mappings'   boolean (default: 0)
@@ -166,12 +171,6 @@ behaves:
                         global
    This option defines whether the entire line other marks are on will be
    highlighted.
-
-'showmarks_enable_unfocused' boolean (default: 1)        *'showmarks_enable_unfocused'*
-                        global
-   This option defines whether buffers other than the current buffer would
-   have marks on them. By setting this value to 0, only the current focused
-   buffer would show it's marks.
 
 ===============================================================================
 3. Highlighting                                        *showmarks-highlighting*

--- a/plugin/showmarks.vim
+++ b/plugin/showmarks.vim
@@ -36,12 +36,24 @@ endif
 
 " Options: Set up some nice defaults
 if !exists('g:showmarks_enable'      ) | let g:showmarks_enable       = 1    | endif
-if !exists('g:showmarks_auto_toggle' ) | let g:showmarks_auto_toggle  = 1    | endif
 if !exists('g:showmarks_no_mappings' ) | let g:showmarks_no_mappings  = 0    | endif
 if !exists('g:showmarks_ignore_type' ) | let g:showmarks_ignore_type  = "hq" | endif
 if !exists('g:showmarks_hlline_lower') | let g:showmarks_hlline_lower = "0"  | endif
 if !exists('g:showmarks_hlline_upper') | let g:showmarks_hlline_upper = "0"  | endif
 if !exists('g:showmarks_hlline_other') | let g:showmarks_hlline_other = "0"  | endif
+
+" The value of showmarks_auto_toggle was changed to be a list. For backward
+" compatibility reasons, the code still supports it as a number or as a string.
+if !exists('g:showmarks_auto_toggle' ) | let g:showmarks_auto_toggle  = ['cursor_hold'] | endif
+if type(g:showmarks_auto_toggle) == type(0)
+	if g:showmarks_auto_toggle == 1
+		let g:showmarks_auto_toggle = ['cursor_hold']
+	else
+		let g:showmarks_auto_toggle = []
+	endif
+elseif type(g:showmarks_auto_toggle) == type('')
+	let g:showmarks_auto_toggle = [g:showmarks_auto_toggle]
+endif
 
 " Commands
 command! -nargs=0 ShowMarksToggle    :call showmarks#ShowMarksToggle()
@@ -67,7 +79,7 @@ endif
 nnoremap <silent> <script> <unique> m :call showmarks#ShowMarksHooksMark()<CR>
 
 " AutoCommands: Only if ShowMarks is enabled
-if g:showmarks_enable == 1 && g:showmarks_auto_toggle
+if g:showmarks_enable == 1 && index(g:showmarks_auto_toggle, 'cursor_hold') >= 0
 	augroup ShowMarks
 		autocmd!
 		autocmd CursorHold * call showmarks#ShowMarks()
@@ -80,8 +92,8 @@ highlight default ShowMarksHLu ctermfg=darkblue ctermbg=blue cterm=bold guifg=bl
 highlight default ShowMarksHLo ctermfg=darkblue ctermbg=blue cterm=bold guifg=blue guibg=lightblue gui=bold
 highlight default ShowMarksHLm ctermfg=darkblue ctermbg=blue cterm=bold guifg=blue guibg=lightblue gui=bold
 
-if g:showmarks_auto_toggle == 2
-	augroup ShowMarksUnfocused
+if g:showmarks_enable == 1 && index(g:showmarks_auto_toggle, 'current_buffer') >= 0
+	augroup ShowMarksCurrentBuffer
 		autocmd!
 		autocmd BufEnter * call showmarks#ShowMarks()
 		autocmd BufLeave * call showmarks#ShowMarksHideAll()

--- a/plugin/showmarks.vim
+++ b/plugin/showmarks.vim
@@ -42,12 +42,10 @@ if !exists('g:showmarks_ignore_type' ) | let g:showmarks_ignore_type  = "hq" | e
 if !exists('g:showmarks_hlline_lower') | let g:showmarks_hlline_lower = "0"  | endif
 if !exists('g:showmarks_hlline_upper') | let g:showmarks_hlline_upper = "0"  | endif
 if !exists('g:showmarks_hlline_other') | let g:showmarks_hlline_other = "0"  | endif
-if !exists('g:showmarks_enable_unfocused') | let g:showmarks_enable_unfocused = 1  | endif
 
 " Commands
 command! -nargs=0 ShowMarksToggle    :call showmarks#ShowMarksToggle()
 command! -nargs=0 ShowMarksOn        :call showmarks#ShowMarksOn()
-command! -nargs=0 ShowMarksOff       :call showmarks#ShowMarksOff()
 command! -nargs=0 ShowMarksClearMark :call showmarks#ShowMarksClearMark()
 command! -nargs=0 ShowMarksClearAll  :call showmarks#ShowMarksClearAll()
 command! -nargs=0 ShowMarksPlaceMark :call showmarks#ShowMarksPlaceMark()
@@ -82,11 +80,11 @@ highlight default ShowMarksHLu ctermfg=darkblue ctermbg=blue cterm=bold guifg=bl
 highlight default ShowMarksHLo ctermfg=darkblue ctermbg=blue cterm=bold guifg=blue guibg=lightblue gui=bold
 highlight default ShowMarksHLm ctermfg=darkblue ctermbg=blue cterm=bold guifg=blue guibg=lightblue gui=bold
 
-if ! g:showmarks_enable_unfocused
+if g:showmarks_auto_toggle == 2
 	augroup ShowMarksUnfocused
 		autocmd!
-		autocmd BufEnter,FocusGained * call showmarks#ShowMarks()
-		autocmd BufLeave,FocusLost   * call showmarks#ShowMarksHideAll()
+		autocmd BufEnter * call showmarks#ShowMarks()
+		autocmd BufLeave * call showmarks#ShowMarksHideAll()
 	augroup END
 endif
 

--- a/plugin/showmarks.vim
+++ b/plugin/showmarks.vim
@@ -42,10 +42,12 @@ if !exists('g:showmarks_ignore_type' ) | let g:showmarks_ignore_type  = "hq" | e
 if !exists('g:showmarks_hlline_lower') | let g:showmarks_hlline_lower = "0"  | endif
 if !exists('g:showmarks_hlline_upper') | let g:showmarks_hlline_upper = "0"  | endif
 if !exists('g:showmarks_hlline_other') | let g:showmarks_hlline_other = "0"  | endif
+if !exists('g:showmarks_enable_unfocused') | let g:showmarks_enable_unfocused = 1  | endif
 
 " Commands
 command! -nargs=0 ShowMarksToggle    :call showmarks#ShowMarksToggle()
 command! -nargs=0 ShowMarksOn        :call showmarks#ShowMarksOn()
+command! -nargs=0 ShowMarksOff       :call showmarks#ShowMarksOff()
 command! -nargs=0 ShowMarksClearMark :call showmarks#ShowMarksClearMark()
 command! -nargs=0 ShowMarksClearAll  :call showmarks#ShowMarksClearAll()
 command! -nargs=0 ShowMarksPlaceMark :call showmarks#ShowMarksPlaceMark()
@@ -80,6 +82,13 @@ highlight default ShowMarksHLu ctermfg=darkblue ctermbg=blue cterm=bold guifg=bl
 highlight default ShowMarksHLo ctermfg=darkblue ctermbg=blue cterm=bold guifg=blue guibg=lightblue gui=bold
 highlight default ShowMarksHLm ctermfg=darkblue ctermbg=blue cterm=bold guifg=blue guibg=lightblue gui=bold
 
+if ! g:showmarks_enable_unfocused
+	augroup ShowMarksUnfocused
+		autocmd!
+		autocmd BufEnter,FocusGained * call showmarks#ShowMarks()
+		autocmd BufLeave,FocusLost   * call showmarks#ShowMarksHideAll()
+	augroup END
+endif
 
 " -----------------------------------------------------------------------------
 " vim:ts=4:sw=4:noet


### PR DESCRIPTION
Added a functionality to let the plugin have an option that would ignore the marks on buffers other than the current working buffer.

It seems to me that the marks on other buffers are usually useless (at least most of them), so I added a functionality that would let the user disable showing them on buffers other then the current working buffer.